### PR TITLE
Ignore Data Folder for Repo Stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 *.ipynb linguist-language=Python
-data/* linguist-vendored
+data/** linguist-vendored


### PR DESCRIPTION
Update gitattribute file to ignore data folder and its subfolders for repo statistics